### PR TITLE
feat: implement buttons for opening the plugin for specific person;

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { Plugin } from 'obsidian';
 
 import { DEFAULT_SETTINGS, GrafilySettings, GrafilySettingTab } from './settings';
-import { GrafilyView, VIEW_TYPE } from './view/GrafilyView';
+import { GrafilyView, GrafilyViewRequest, VIEW_TYPE } from './view/GrafilyView';
+import { renderNavigationBlock } from './view/navigationBlock';
 
 import '@xyflow/react/dist/style.css';
 import { GraphDto } from 'view/graph';
@@ -28,14 +29,19 @@ export default class Grafily extends Plugin {
 
         this.registerView(VIEW_TYPE, (leaf) => new GrafilyView(leaf, this.settings.dataDir, this));
 
+        this.registerMarkdownCodeBlockProcessor('grafily-navigation', (_source, el, ctx) => {
+            renderNavigationBlock(el, ctx, this);
+        });
+
         this.addSettingTab(new GrafilySettingTab(this.app, this));
     }
 
-    async activateView() {
+    async activateView(request?: GrafilyViewRequest) {
         const leaf = this.app.workspace.getLeaf(true);
         await leaf.setViewState({
             type: VIEW_TYPE,
             active: true,
+            state: request,
         });
     }
 

--- a/src/view/GrafilyView.tsx
+++ b/src/view/GrafilyView.tsx
@@ -1,15 +1,33 @@
 import { StrictMode, createContext } from 'react';
-import { ItemView, WorkspaceLeaf, App, Plugin } from 'obsidian';
+import { ItemView, WorkspaceLeaf, App, Plugin, ViewStateResult } from 'obsidian';
 import { Root, createRoot } from 'react-dom/client';
 
 import { FamilyFlow } from './graph';
+import { LayoutName } from 'layout';
 
 export const VIEW_TYPE = 'grafily-view';
 
-const ReactView = ({ plugin, dataDir }: { plugin: Plugin; dataDir: string }) => {
+/**
+ * A request to immediately build a graph for the given person, skipping the startup menu.
+ * Used to open the view directly from the `grafily-navigation` code block.
+ */
+export type GrafilyViewRequest = {
+    layoutName: LayoutName;
+    personId: string;
+};
+
+const ReactView = ({
+    plugin,
+    dataDir,
+    initialRequest,
+}: {
+    plugin: Plugin;
+    dataDir: string;
+    initialRequest: GrafilyViewRequest | null;
+}) => {
     return (
         <div style={{ width: '100%', height: '100%' }}>
-            <FamilyFlow plugin={plugin} dataDir={dataDir} />
+            <FamilyFlow plugin={plugin} dataDir={dataDir} initialRequest={initialRequest} />
         </div>
     );
 };
@@ -21,6 +39,7 @@ export class GrafilyView extends ItemView {
     root: Root | null = null;
     plugin: Plugin | null = null;
     dataDir: string;
+    initialRequest: GrafilyViewRequest | null = null;
 
     constructor(leaf: WorkspaceLeaf, dataDir: string, plugin?: Plugin) {
         super(leaf);
@@ -38,11 +57,31 @@ export class GrafilyView extends ItemView {
 
     async onOpen() {
         this.root = createRoot(this.contentEl);
-        this.root.render(
+        this.renderReactRoot();
+    }
+
+    async setState(state: unknown, result: ViewStateResult): Promise<void> {
+        const request = state as GrafilyViewRequest | null;
+        if (request?.layoutName && request?.personId) {
+            this.initialRequest = request;
+            if (this.root) {
+                this.renderReactRoot();
+            }
+        }
+
+        await super.setState(state, result);
+    }
+
+    private renderReactRoot() {
+        this.root?.render(
             <AppContext.Provider value={this.app}>
                 <PluginContext.Provider value={this.plugin || undefined}>
                     <StrictMode>
-                        <ReactView plugin={this.plugin!} dataDir={this.dataDir} />
+                        <ReactView
+                            plugin={this.plugin!}
+                            dataDir={this.dataDir}
+                            initialRequest={this.initialRequest}
+                        />
                     </StrictMode>
                 </PluginContext.Provider>
             </AppContext.Provider>,

--- a/src/view/graph.tsx
+++ b/src/view/graph.tsx
@@ -32,6 +32,7 @@ import { SelectedPerson, SidePanel } from './SidePanel';
 import { App, Plugin } from 'obsidian';
 import { DEFAULT_STATE, GrafilyState } from 'main';
 import { confirmDialog } from './ConfirmModal';
+import type { GrafilyViewRequest } from './GrafilyView';
 
 export type GraphContextValue = {
     layout: GenericLayout;
@@ -88,7 +89,15 @@ async function scanVaultForPersons(app: App, dataDir: string): Promise<Index> {
     return buildIndex(family);
 }
 
-function FamilyGraph({ plugin, dataDir }: { plugin: Plugin; dataDir: string }) {
+function FamilyGraph({
+    plugin,
+    dataDir,
+    initialRequest,
+}: {
+    plugin: Plugin;
+    dataDir: string;
+    initialRequest?: GrafilyViewRequest | null;
+}) {
     const [layout, setLayout] = useState<GenericLayout>(DEFAULT_EMPTY_LAYOUT);
     const [index, setIndex] = useState<Index>(emptyIndex());
 
@@ -120,6 +129,21 @@ function FamilyGraph({ plugin, dataDir }: { plugin: Plugin; dataDir: string }) {
             cancelled = true;
         };
     }, [app]);
+
+    useEffect(() => {
+        if (!initialRequest || index.personById.size < 1) {
+            console.warn('Initial request is not defined or index is not populated yet');
+            return;
+        }
+
+        if (index.personById.has(initialRequest.personId)) {
+            handleBuildGraph(initialRequest.layoutName, initialRequest.personId);
+        } else {
+            console.error(
+                `Grafily navigation: person "${initialRequest.personId}" was not found in "${dataDir}".`,
+            );
+        }
+    }, [initialRequest, index]);
 
     useEffect(() => {
         if (!plugin) {
@@ -520,7 +544,15 @@ function FamilyGraph({ plugin, dataDir }: { plugin: Plugin; dataDir: string }) {
     );
 }
 
-export function FamilyFlow({ plugin, dataDir }: { plugin: Plugin; dataDir: string }) {
+export function FamilyFlow({
+    plugin,
+    dataDir,
+    initialRequest,
+}: {
+    plugin: Plugin;
+    dataDir: string;
+    initialRequest?: GrafilyViewRequest | null;
+}) {
     return (
         <div
             style={{
@@ -530,7 +562,7 @@ export function FamilyFlow({ plugin, dataDir }: { plugin: Plugin; dataDir: strin
             }}
         >
             <ReactFlowProvider>
-                <FamilyGraph plugin={plugin} dataDir={dataDir} />
+                <FamilyGraph plugin={plugin} dataDir={dataDir} initialRequest={initialRequest} />
             </ReactFlowProvider>
         </div>
     );

--- a/src/view/navigationBlock.ts
+++ b/src/view/navigationBlock.ts
@@ -1,0 +1,45 @@
+import { MarkdownPostProcessorContext, TFile } from 'obsidian';
+
+import Grafily from '../main';
+import { BRANDES_KORF, REINGOLD_TILFORD } from '../layout';
+
+/**
+ * Renders the `grafily-navigation` code block: two buttons that open the Grafily view in a new
+ * tab, using the current page's person as the starting person.
+ */
+export function renderNavigationBlock(
+    el: HTMLElement,
+    ctx: MarkdownPostProcessorContext,
+    plugin: Grafily,
+) {
+    const file = plugin.app.vault.getAbstractFileByPath(ctx.sourcePath);
+    const personId = file instanceof TFile ? file.basename : null;
+
+    const container = el.createDiv({ cls: 'grafily-navigation-block' });
+
+    const treeButton = container.createEl('button', {
+        cls: 'grafily-navigation-button',
+        text: 'Family tree',
+    });
+    const explorerButton = container.createEl('button', {
+        cls: 'grafily-navigation-button',
+        text: 'Graph explorer',
+    });
+
+    if (!personId) {
+        treeButton.disabled = true;
+        explorerButton.disabled = true;
+        return;
+    }
+
+    treeButton.onclick = () => {
+        plugin
+            .activateView({ layoutName: REINGOLD_TILFORD, personId })
+            .catch((err) => console.error(err));
+    };
+    explorerButton.onclick = () => {
+        plugin
+            .activateView({ layoutName: BRANDES_KORF, personId })
+            .catch((err) => console.error(err));
+    };
+}

--- a/styles.css
+++ b/styles.css
@@ -612,6 +612,19 @@ If your plugin does not need CSS, delete this file.
     border: 2px solid #e3dfc1;
 }
 
+/* Navigation code block */
+.grafily-navigation-block {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    margin: 8px 0;
+    width: fit-content;
+}
+
+.grafily-navigation-button {
+    flex: 1;
+}
+
 /* node_modules/@xyflow/react/dist/style.css */
 .react-flow {
     direction: ltr;


### PR DESCRIPTION
This PR implements a new code block type `grafily-navigation`. The user should leave it empty:

<img width="536" height="176" alt="image" src="https://github.com/user-attachments/assets/8ac2a0e0-47d5-457b-954f-2e1e3b12027c" />

This code block renders as two buttons:

<img width="601" height="142" alt="image" src="https://github.com/user-attachments/assets/2d0eb804-b563-4d70-911e-2934ba2f24ba" />

When the user clicks on any of those buttons, the grafily plugin will be opened in a new tab. If the user clicks the left button (`Family tree`), the direct family tree will be built and rendered with the current person at its center. If the user clicks the right button (`Graph explorer`), the family graph will be built and rendered, starting with the current person. Example:

| `Family tree` | `Family graph` |
|-|-|
| <img width="1509" height="687" alt="image" src="https://github.com/user-attachments/assets/80b49b79-eee1-4ce8-b224-0607493da220" /> | <img width="1543" height="670" alt="image" src="https://github.com/user-attachments/assets/c0f869d0-61c3-4784-8132-ab4251425df2" /> |