### PR TITLE
feat: add grafily file menu options;

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
-import { Plugin } from 'obsidian';
+import { Menu, MenuItem, Plugin, TAbstractFile, TFile } from 'obsidian';
 
 import { DEFAULT_SETTINGS, GrafilySettings, GrafilySettingTab } from './settings';
 import { GrafilyView, GrafilyViewRequest, VIEW_TYPE } from './view/GrafilyView';
 import { renderNavigationBlock } from './view/navigationBlock';
+import { extractPageMeta } from './parsing';
+import { BRANDES_KORF, REINGOLD_TILFORD } from './layout';
 
 import '@xyflow/react/dist/style.css';
 import { GraphDto } from 'view/graph';
@@ -19,6 +21,13 @@ export const DEFAULT_STATE: GrafilyState = {
 
 export default class Grafily extends Plugin {
     settings: GrafilySettings;
+    // Maps a person page's file path to its person id. Obsidian shows the `file-menu` context
+    // menu synchronously right after firing the event, so `handleFileMenu` cannot read and parse
+    // the file (an async operation) before deciding whether to add the Grafily item — by the time
+    // that read resolves, the menu may already be shown, and `menu.addItem` silently does nothing.
+    // This index is kept up to date ahead of time instead, so `handleFileMenu` only needs a
+    // synchronous lookup.
+    private personIdByPath = new Map<string, string>();
 
     async onload() {
         await this.loadSettings();
@@ -34,6 +43,110 @@ export default class Grafily extends Plugin {
         });
 
         this.addSettingTab(new GrafilySettingTab(this.app, this));
+
+        this.app.workspace.onLayoutReady(() => {
+            this.refreshPersonIndex().catch((err) => console.error(err));
+        });
+
+        this.registerEvent(
+            this.app.vault.on('modify', (file) => {
+                if (file instanceof TFile) {
+                    this.updatePersonIndexEntry(file).catch((err) => console.error(err));
+                }
+            }),
+        );
+        this.registerEvent(
+            this.app.vault.on('delete', (file) => {
+                this.personIdByPath.delete(file.path);
+            }),
+        );
+        this.registerEvent(
+            this.app.vault.on('rename', (file, oldPath) => {
+                this.personIdByPath.delete(oldPath);
+
+                if (file instanceof TFile) {
+                    this.updatePersonIndexEntry(file).catch((err) => console.error(err));
+                }
+            }),
+        );
+
+        this.registerEvent(
+            this.app.workspace.on('file-menu', (menu, file) => {
+                this.handleFileMenu(menu, file);
+            }),
+        );
+    }
+
+    private async refreshPersonIndex() {
+        const personIdByPath = new Map<string, string>();
+
+        for (const file of this.app.vault.getFiles()) {
+            if (!file.path.startsWith(this.settings.dataDir) || file.extension !== 'md') {
+                continue;
+            }
+
+            try {
+                const content = await this.app.vault.cachedRead(file);
+                const person = extractPageMeta(content, file.basename, file);
+
+                personIdByPath.set(file.path, person.id);
+            } catch {
+                // Not a valid person page; leave it out of the index.
+            }
+        }
+
+        this.personIdByPath = personIdByPath;
+    }
+
+    private async updatePersonIndexEntry(file: TFile) {
+        if (!file.path.startsWith(this.settings.dataDir) || file.extension !== 'md') {
+            this.personIdByPath.delete(file.path);
+            return;
+        }
+
+        try {
+            const content = await this.app.vault.cachedRead(file);
+            const person = extractPageMeta(content, file.basename, file);
+
+            this.personIdByPath.set(file.path, person.id);
+        } catch {
+            this.personIdByPath.delete(file.path);
+        }
+    }
+
+    handleFileMenu(menu: Menu, file: TAbstractFile) {
+        if (!(file instanceof TFile)) {
+            return;
+        }
+
+        const personId = this.personIdByPath.get(file.path);
+        if (!personId) {
+            return;
+        }
+
+        menu.addItem((item: MenuItem) => {
+            item.setTitle('Grafily').setIcon('network');
+
+            // `setSubmenu` is not part of Obsidian's public API typings, but it is the standard
+            // way plugins (and Obsidian's own "Copy path" item) nest options under a parent one.
+            const submenu = (item as MenuItem & { setSubmenu: () => Menu }).setSubmenu();
+
+            submenu.addItem((subItem) =>
+                subItem.setTitle('Family tree').onClick(() => {
+                    this.activateView({ layoutName: REINGOLD_TILFORD, personId }).catch((err) =>
+                        console.error(err),
+                    );
+                }),
+            );
+
+            submenu.addItem((subItem) =>
+                subItem.setTitle('Graph explorer').onClick(() => {
+                    this.activateView({ layoutName: BRANDES_KORF, personId }).catch((err) =>
+                        console.error(err),
+                    );
+                }),
+            );
+        });
     }
 
     async activateView(request?: GrafilyViewRequest) {


### PR DESCRIPTION
File menu options added by grafily are available when the user clicks with the right mouse button

- on the note tab

<img width="537" height="917" alt="image" src="https://github.com/user-attachments/assets/58ca11d1-040d-4781-9d6a-e41b6c8352af" />

- on the node in the file navigator

<img width="509" height="468" alt="image" src="https://github.com/user-attachments/assets/4573fb38-d460-4545-b5e3-71dc288bb1ba" />

- on the node link

<img width="678" height="714" alt="image" src="https://github.com/user-attachments/assets/f62b8ddd-a4a0-4846-aff2-5ef63e8c8aca" />
